### PR TITLE
Support MySQL dumps that include "CREATE DATABASE IF NOT EXISTS"

### DIFF
--- a/lib/SQL/Parser.php
+++ b/lib/SQL/Parser.php
@@ -396,7 +396,7 @@ class SQL_Parser {
         // create_specification:
         //      [DEFAULT] {CHARACTER SET | CHARSET} [=] charset_name
         //    | [DEFAULT] COLLATE [=] collation_name
-              
+        $this->maybe('IF NOT EXISTS');
         $this->schema->name = $this->get_ident();
         $this->get_create_specification();
     }

--- a/lib/SQL/Tokenizer.php
+++ b/lib/SQL/Tokenizer.php
@@ -756,6 +756,7 @@ class SQL_Tokenizer {
             "HOUR_MINUTE",
             "HOUR_SECOND",
             "IF EXISTS",
+            "IF NOT EXISTS",
             "IN",
             "INDEX",
             "INNODB",


### PR DESCRIPTION
MySQL dumps where you specify a list of databases include an "IF NOT EXISTS" clause on its "CREATE DATABASE" statement. 
