### PR TITLE
Properly support changing only the default character set

### DIFF
--- a/lib/SQL/Diff.php
+++ b/lib/SQL/Diff.php
@@ -434,7 +434,7 @@ class SQL_Changeset {
                     count($this->update['tables']) + count($this->update['routines'])+
                     count($this->update['events']) + count($this->update['views'])
                     );
-        return $changed != 0;
+        return ($changed != 0 or $this->create_sqlmeta or isset($this->schema->charset) or isset($this->schema->collate));
     }
 }
 

--- a/lib/SQL/Generator/SQL.php
+++ b/lib/SQL/Generator/SQL.php
@@ -428,7 +428,12 @@ class SQL_Generator_SQL {
     }
 
     function create_column( $column ) {
-        $this->extend("%id %lit", $column->name, $column->type->toSql() );
+        if ( isset($column->from) ) {
+            $this->extend("%id %lit", $column->name, $column->type->toSql($column->from->type) );
+        }
+        else {
+            $this->extend("%id %lit", $column->name, $column->type->toSql() );
+        }
         if ( ! $column->null ) {
             $this->add( " NOT NULL" );
         }

--- a/lib/SQL/Types.php
+++ b/lib/SQL/Types.php
@@ -448,7 +448,6 @@ class SQL_String extends SQL_Type {
         return SQL::quote_str( $value );
     }
     function charset_collation($other=null) {
-        $sql = "";
         $other_charset = isset($other)? $other->charset(): $this->default_charset;
         $other_collate = isset($other)? $other->collate(): $this->default_collate;
         $diff_charset = $this->charset() != $other_charset;
@@ -461,6 +460,7 @@ class SQL_String extends SQL_Type {
                 return " UNICODE";
             }
         }
+        $sql = "";
         if ( $diff_charset ) {
             $sql .= " CHARACTER SET ".$this->charset();
         }


### PR DESCRIPTION
Changing the default character set results in changes to the character set in any table where you don't specifically set a character set, however the diffs being generated didn't correctly reveal this... they showed the columns as changing, but didn't show any differences.
