### PR TITLE
s/ROUTINE/Routine/g

### DIFF
--- a/Modyllic/Generator/PHP.php
+++ b/Modyllic/Generator/PHP.php
@@ -581,7 +581,7 @@ class Modyllic_Generator_PHP {
         }
     }
     function end_txns($routine) {
-        if ($routine->txns == Modyllic_ROUTINE::TXNS_CALL ) {
+        if ($routine->txns == Modyllic_Routine::TXNS_CALL ) {
             $this->begin_cmd( 'if ( ')
                    ->func_var( 'isset', 'commitTransaction' )
                  ->end_cmd(' ) {')

--- a/Modyllic/Generator/SQL.php
+++ b/Modyllic/Generator/SQL.php
@@ -634,7 +634,7 @@ class Modyllic_Generator_SQL {
                 $meta["returns"] = $routine->returns;
             }
         }
-        if ( $routine->txns != Modyllic_ROUTINE::TXNS_DEFAULT ) {
+        if ( $routine->txns != Modyllic_Routine::TXNS_DEFAULT ) {
             $meta["txns"] = $routine->txns;
         }
         return $meta;


### PR DESCRIPTION
Fix bogus case when referencing some static constants
