### PR TITLE
Merge in the 'sqlmeta_exists' flag

### DIFF
--- a/Modyllic/Schema.php
+++ b/Modyllic/Schema.php
@@ -62,6 +62,9 @@ class Modyllic_Schema extends Modyllic_Diffable {
         foreach ($schema->events as &$event) {
             $this->add_event($event);
         }
+        if ($schema->sqlmeta_exists) {
+            $this->sqlmeta_exists = $schema->sqlmeta_exists;
+        }
     }
     
     /**


### PR DESCRIPTION
Since treating all DB schemas as implicit subschemas in Modyllic::Loader::load means that the flag is never put any place visible.
