### PR TITLE
Progressively build a schema rather then loading and merging

### DIFF
--- a/Modyllic/Loader.php
+++ b/Modyllic/Loader.php
@@ -21,27 +21,28 @@ class Modyllic_Loader_Exception extends Exception {}
  */
 class Modyllic_Loader {
 
-    static function load(array $sources) {
-        $schema = new Modyllic_Schema();
+    static function load(array $sources,$schema=null) {
+        if ( !isset($schema) ) {
+            $schema = new Modyllic_Schema();
+        }
         Modyllic_Status::$sourceCount += count($sources);
         foreach ($sources as $source) {
             Modyllic_Status::$sourceName = $source;
             Modyllic_Status::$sourceIndex ++;
 
             if ( is_dir($source) ) {
-                $subschema = Modyllic_Loader_Dir::load($source);
+                Modyllic_Loader_Dir::load($source, $schema);
             }
             else if ( file_exists($source) ) {
-                $subschema = Modyllic_Loader_File::load($source);
+                Modyllic_Loader_File::load($source, $schema);
             }
             else if ( Modyllic_Loader_DB::is_dsn($source) ) {
-                $subschema = Modyllic_Loader_DB::load($source);
+                Modyllic_Loader_DB::load($source, $schema);
             }
             else {
                 throw new Modyllic_Loader_Exception("Could not load $source, file or directory not found");
             }
 
-            $schema->merge($subschema);
             Modyllic_Status::status( 1, 1 );
 
         }

--- a/Modyllic/Loader/DB.php
+++ b/Modyllic/Loader/DB.php
@@ -74,7 +74,7 @@ class Modyllic_Loader_DB {
         }
     }
 
-    static function load( $source ) {
+    static function load( $source, $schema ) {
         list( $driver, $dsn, $dbname, $username, $password ) = self::parse_dsn($source);
         Modyllic_Status::$sourceName = $dsn;
 
@@ -82,8 +82,6 @@ class Modyllic_Loader_DB {
 
         $dbh = new PDO( $dsn, $username, $password, array( PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION, PDO::ATTR_EMULATE_PREPARES=>TRUE ) );
 
-        $schema = call_user_func( array($class,'load'), $dbh, $dbname );
-
-        return $schema;
+        call_user_func( array($class,'load'), $dbh, $dbname, $schema );
     }
 }

--- a/Modyllic/Loader/DB/MySQL.php
+++ b/Modyllic/Loader/DB/MySQL.php
@@ -37,7 +37,7 @@ class Modyllic_Loader_DB_MySQL {
     /**
      * @returns Modyllic_Schema
      */
-    static function load($dbh, $dbname) {
+    static function load($dbh, $dbname, $schema) {
         $dbh->exec("USE information_schema");
         $dbschema = self::selectrow( $dbh, "SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM SCHEMATA WHERE SCHEMA_NAME=?", array($dbname) );
         if ( ! $dbschema ) {
@@ -45,7 +45,6 @@ class Modyllic_Loader_DB_MySQL {
         }
 
         $parser = new Modyllic_Parser();
-        $schema = new Modyllic_Schema();
 
         $schema->name = $dbschema['SCHEMA_NAME'];
         $schema->nameIsDefault = false;
@@ -111,6 +110,5 @@ class Modyllic_Loader_DB_MySQL {
             }
         }
 
-        return $schema;
     }
 }

--- a/Modyllic/Loader/Dir.php
+++ b/Modyllic/Loader/Dir.php
@@ -7,9 +7,9 @@
  */
 
 class Modyllic_Loader_Dir {
-    static function load( $dir ) {
+    static function load( $dir, $schema ) {
         $filelist = glob("$dir/*.sql",GLOB_NOSORT);
         natsort($filelist);
-        return Modyllic_Loader::load( $filelist );
+        Modyllic_Loader::load( $filelist, $schema );
     }
 }

--- a/Modyllic/Loader/File.php
+++ b/Modyllic/Loader/File.php
@@ -7,7 +7,7 @@
  */
 
 class Modyllic_Loader_File {
-    static function load( $file ) {
+    static function load( $file, $schema ) {
         # A preparsed schemafile will have a .sqlc extension
         $file_bits = explode(".",$file);
         array_pop($file_bits);
@@ -23,16 +23,15 @@ class Modyllic_Loader_File {
                 throw new Modyllic_Loader_Exception("Error opening $file");
             }
             $parser = new Modyllic_Parser();
-            $schema = new Modyllic_Schema();
-            $schema = $parser->partial($schema, $data, $file, ";" );
+            $parser->partial($schema, $data, $file, ";" );
         }
         else {
             if ( ($data = @file_get_contents($sqlc_file)) === FALSE ) {
                 throw new Modyllic_Loader_Exception("Error opening $sqlc_file");
             }
-            $schema = unserialize($data);
+            $subschema = unserialize($data);
+            $schema->merge( $subschema );
         }
-        return $schema;
     }
 
 }


### PR DESCRIPTION
Previously, we built a new independent schema for each file, then merged that into a top level schema.  With this new system, we pass the schema along to the loaders and use the parser's ->partial option to add to it.
