### PR TITLE
Improve error messages for invalid delimiters (#82)

### DIFF
--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -86,7 +86,7 @@ class Modyllic_Parser {
     function next($whitespace=false) {
         $next = $this->tok->next($whitespace);
         if ( $next instanceOf Modyllic_Token_Error ) {
-            throw $this->error( "Syntax error" );
+            throw $this->error( $next->value() );
         }
         return $next;
     }

--- a/test/General_Functional.t
+++ b/test/General_Functional.t
@@ -59,3 +59,17 @@ $table = $schema->tables['test'];
 $index = array_pop($table->indexes);
 is( $index->name, "id", "Generated index name is correct");
 is( $index->dynamic_name, true, "Generated index name is flagged as dynamic");
+
+$msg = "Trailing words on DELIMITERs produce reasonable error messages";
+try {
+    $sql = 'DELIMITER ; |';
+    $schema = $parser->parse($sql);
+    fail($msg);
+}
+catch (Modyllic_Exception $e) {
+    if ( ! ok( ! preg_match("/Modyllic_Token/",$e->getMessage()), $msg ) ) {
+        foreach (explode("\n",$e->getMessage()) as $line) {
+            diag($line);
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/OnlineBuddies/Modyllic/issues/82 by capturing the invalid part of the delimiter line and emitting an Error token rather then letting the delimiter statement pass through to other matchers.  This also patches the parser to use the error message from the error token rather then making up its own.
