### PR TITLE
RETURNS COLUMN assertions should allow empty result sets (#56)

### DIFF
--- a/Modyllic/Generator/PHP.php
+++ b/Modyllic/Generator/PHP.php
@@ -1224,6 +1224,12 @@ class Modyllic_Generator_PHP {
                ->end_method()
              ->end_assign();
         $this->method('sth','closeCursor');
+        $this->begin_cmd( 'if (! isset(' )
+               ->add_var('row')
+             ->end_cmd(') ) {')
+             ->begin_block()
+               ->cmd('return',';')
+             ->end_block('}');
         $this->begin_assert()
                ->begin_cmd( 'isset(' )
                  ->index( 'row', $routine->returns['column'] )


### PR DESCRIPTION
This implements #56, simply returning without a value if the proc didn't return any rows.
