### PR TITLE
Stop using 5.3 Exception form and just rethrow non-general errors

### DIFF
--- a/Modyllic/Generator/PHP.php
+++ b/Modyllic/Generator/PHP.php
@@ -1133,21 +1133,11 @@ class Modyllic_Generator_PHP {
                      ->add_str('General error while fetching return value of '.$routine->name.
                          '; this usually means that you declared this routine as having a return value '.
                          'but it does not actually select any data before completing.')
-                     ->sep()
-                     ->add('0')
-                     ->sep()
-                     ->add_var('e')
                    ->end_new()
                  ->end_throw()
                ->begin_else()
                  ->begin_throw()
-                   ->begin_new('PDOException')
-                     ->add_str('Error while fetching return value of '.$routine->name)
-                     ->sep()
-                     ->add('0')
-                     ->sep()
-                     ->add_var('e')
-                   ->end_new()
+                   ->add_var('e')
                  ->end_throw()
                ->end_if()
              ->end_try();


### PR DESCRIPTION
All proc fetches are wrapped up in a try/catch block that catches general errors and provides some diagnostic hints.  (General errors, in this case, are almost always caused by calling fetch after calling a proc that didn't call SELECT.)

This patch makes them work with PHP 5.2-- it had previously been bundling the original exception along in 5.3's previous exception slot.

This also now simply rethrows non-general errors rather then wrapping them.
