### PR TITLE
Migrate fix

### DIFF
--- a/Modyllic/Commandline.php
+++ b/Modyllic/Commandline.php
@@ -37,6 +37,10 @@ class Modyllic_Commandline {
         }
         return $parser;
     }
+    
+    static function displayError( $msg ) {
+        self::getParser()->displayError( $msg );
+    }
 
     static function getArgs( $argSpec ) {
         $parser = self::getParser();

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -36,17 +36,14 @@ $args = Modyllic_Commandline::getArgs(array(
         ));
 
 if ( ! isset($args->options['fromschema']) ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( 'the fromschema is required');
+    Modyllic_Commandline::displayError( 'the fromschema is required');
 }
 if ( ! isset($args->options['toschema']) ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( 'the toschema is required');
+    Modyllic_Commandline::displayError( 'the toschema is required');
 }
 
 if ( ! Modyllic_Loader_DB::is_dsn($args->options['fromschema']) ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( 'the fromschema must be a database');
+    Modyllic_Commandline::displayError( 'the fromschema must be a database');
 }
 
 list( $driver, $dsn, $dbname, $user, $pass ) = Modyllic_Loader_DB::parse_dsn($args->options['fromschema']);
@@ -56,7 +53,12 @@ $sth = $dbh->prepare('SELECT COUNT(*) FROM information_schema.SCHEMATA WHERE SCH
 $sth->execute(array($dbname));
 list($count) = $sth->fetch(PDO::FETCH_NUM);
 if ( $count == 0 ) {
-    $dbh->exec("CREATE DATABASE ".Modyllic_SQL::quote_ident($dbname));
+    if ( $args->options['create'] ) {
+        $dbh->exec("CREATE DATABASE ".Modyllic_SQL::quote_ident($dbname));
+    }
+    else {
+        Modyllic_Commandline::displayError( 'could not connect to database '.$dbname );
+    }
 }
 
 try {

--- a/scripts/sqldiff
+++ b/scripts/sqldiff
@@ -36,8 +36,7 @@ $args = Modyllic_Commandline::getArgs(array(
         )));
 
 if ( (isset($args->options['fromschema']) or isset($args->options['toschema'])) and isset($args->args['fromschema']) ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( "You can't specify a schema both positionally and via options" );
+    Modyllic_Commandline::displayError( "You can't specify a schema both positionally and via options" );
 }
 
 $fromschema = array();
@@ -48,8 +47,7 @@ if ( isset($args->options['fromschema']) ) {
     $fromschema += $args->options['fromschema'];
 }
 if ( count($fromschema) == 0 ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( 'You must specify a from schema to compare');
+    Modyllic_Commandline::displayError( 'You must specify a from schema to compare');
 }
 
 $toschema = array();
@@ -60,8 +58,7 @@ if ( isset($args->options['toschema']) ) {
     $toschema += $args->options['toschema'];
 }
 if ( count($fromschema) == 0 ) {
-    $parser = Modyllic_Commandline::getParser();
-    $parser->displayError( 'You must specify a to schema to compare');
+    Modyllic_Commandline::displayError( 'You must specify a to schema to compare');
 }
 
 $from = Modyllic_Commandline::schema($fromschema);


### PR DESCRIPTION
This pull request fixes the --create option to migrate.  It also adds a static displayError, to clean up the common case of grabbing a Commandline_Parser instance and then calling displayError on that.
