### PR TITLE
Make the SQL generator able to only output specific kinds of data

### DIFF
--- a/Modyllic/Generator/PlainSQL.php
+++ b/Modyllic/Generator/PlainSQL.php
@@ -15,6 +15,7 @@ class Modyllic_Generator_PlainSQL extends Modyllic_Generator_SQL {
     }
 
     function create_sqlmeta() {}
+    function drop_sqlmeta() {}
     function insert_meta($kind,$which,array $what) {}
     function delete_meta($kind,$which) {}
     function update_meta($kind,$which,$what) {}

--- a/scripts/sqldiff
+++ b/scripts/sqldiff
@@ -10,6 +10,7 @@
 require_once "Modyllic/Commandline.php";
 require_once "Modyllic/Diff.php";
 require_once "Modyllic/Generator.php";
+require_once "Modyllic/Generator/SQL.php";
 
 $args = Modyllic_Commandline::getArgs(array(
     'description' => 'Generate a PHP helper class for the stored procs in the schema',
@@ -29,11 +30,26 @@ $args = Modyllic_Commandline::getArgs(array(
             'long_name'   => '--dialect',
             'description' => 'dialect to output in',
             'action'      => 'Dialect',
-            'default'     => 'Modyllic_Generator_NativeSQL' ) ),
+            'default'     => 'Modyllic_Generator_NativeSQL',
+            ),
+        'only' => array(
+            'long_name'   => '--only',
+            'description' => 'comma separated list of kinds of schema objects to process: database, sqlmeta, tables, views, routines, events, triggers',
+            'action'      => 'StoreString',
+            'default'     => implode(",",Modyllic_Generator_SQL::schema_types())
+            ) ),
     'arguments' => array(
         'fromschema' => array('optional'=>true),
         'toschema' => array('optional'=>true)
         )));
+
+try {
+    $only = preg_split('/\s*,\s*/',$args->options['only']);
+    Modyllic_Generator_SQL::validate_schema_types($only);
+}
+catch (Exception $e) {
+    Modyllic_Commandline::displayError($e->getMessage());
+}
 
 if ( (isset($args->options['fromschema']) or isset($args->options['toschema'])) and isset($args->args['fromschema']) ) {
     Modyllic_Commandline::displayError( "You can't specify a schema both positionally and via options" );
@@ -74,4 +90,4 @@ if ( ! $diff->changeset->has_changes() ) {
 $class = Modyllic_Generator::dialectToClass( $args->options['dialect'] );
 $gen = new $class();
 
-print $gen->alter_sql($diff);
+print $gen->alter_sql($diff, ';;', true, $only);

--- a/scripts/sqldrop
+++ b/scripts/sqldrop
@@ -9,6 +9,7 @@
 
 require_once "Modyllic/Commandline.php";
 require_once "Modyllic/Generator.php";
+require_once "Modyllic/Generator/SQL.php";
 
 $args = Modyllic_Commandline::getArgs(array(
     'description' => 'Display drop statements for a schema',
@@ -18,7 +19,14 @@ $args = Modyllic_Commandline::getArgs(array(
             'long_name'   => '--dialect',
             'description' => 'dialect to output in',
             'action'      => 'Dialect',
-            'default'     => 'Modyllic_Generator_NativeSQL' ) ),
+            'default'     => 'Modyllic_Generator_NativeSQL',
+            ),
+        'only' => array(
+            'long_name'   => '--only',
+            'description' => 'comma separated list of kinds of schema objects to process: database, sqlmeta, tables, views, routines, events, triggers',
+            'action'      => 'StoreString',
+            'default'     => implode(",",Modyllic_Generator_SQL::schema_types())
+            ) ),
     'arguments' => array(
         'spec' => array('multiple'=>true) )));
 
@@ -27,4 +35,12 @@ $schema = Modyllic_Commandline::schema($args->args['spec']);
 $class = Modyllic_Generator::dialectToClass( $args->options['dialect'] );
 $gen = new $class();
 
-print $gen->drop_sql( $schema );
+try {
+    $only = preg_split('/\s*,\s*/',$args->options['only']);
+    Modyllic_Generator_SQL::validate_schema_types($only);
+}
+catch (Exception $e) {
+    Modyllic_Commandline::displayError($e->getMessage());
+}
+
+print $gen->drop_sql( $schema, ';;', true, $only );

--- a/scripts/sqldump
+++ b/scripts/sqldump
@@ -9,6 +9,7 @@
 
 require_once "Modyllic/Commandline.php";
 require_once "Modyllic/Generator.php";
+require_once "Modyllic/Generator/SQL.php";
 
 $args = Modyllic_Commandline::getArgs(array(
     'description' => 'Load one or more schema and print them out',
@@ -18,7 +19,14 @@ $args = Modyllic_Commandline::getArgs(array(
             'long_name'   => '--dialect',
             'description' => 'dialect to output in',
             'action'      => 'Dialect',
-            'default'     => 'Modyllic_Generator_NativeSQL' ) ),
+            'default'     => 'Modyllic_Generator_NativeSQL',
+            ),
+        'only' => array(
+            'long_name'   => '--only',
+            'description' => 'comma separated list of kinds of schema objects to process: database, sqlmeta, tables, views, routines, events, triggers',
+            'action'      => 'StoreString',
+            'default'     => implode(",",Modyllic_Generator_SQL::schema_types())
+            ) ),
     'arguments' => array(
         'spec' => array('multiple'=>true) )));
 
@@ -27,4 +35,12 @@ $schema = Modyllic_Commandline::schema($args->args['spec']);
 $class = Modyllic_Generator::dialectToClass( $args->options['dialect'] );
 $gen = new $class();
 
-print $gen->create_sql( $schema );
+try {
+    $only = preg_split('/\s*,\s*/',$args->options['only']);
+    Modyllic_Generator_SQL::validate_schema_types($only);
+}
+catch (Exception $e) {
+    Modyllic_Commandline::displayError($e->getMessage());
+}
+
+print $gen->create_sql( $schema, ';;', true, $only );

--- a/test/generator/Triggers.t
+++ b/test/generator/Triggers.t
@@ -78,7 +78,7 @@ require_ok("Modyllic/Diff.php");
 $diff = new Modyllic_Diff($schema1,$schema2);
 
 $gen = new Modyllic_Generator_SQL();
-$sql = $gen->alter( $diff )->sql_commands();
+$sql = $gen->alter( $diff, array('triggers') )->sql_commands();
 
 is( count($sql), 2, "Diff requires two SQL commands" );
 


### PR DESCRIPTION
We modify the SQL generator and the various commandline tools to allow dumping of only certain classes of schema object.  This is still limited, in that it will -load- all types of objects and only filter on its output.  It would be desirable to only load the objects we're interested, but that will require some refactoring.
