### PR TITLE
Fix #109, allow index comparisions able to be aware of column name aliases

### DIFF
--- a/Modyllic/Diff.php
+++ b/Modyllic/Diff.php
@@ -248,7 +248,7 @@ class Modyllic_Diff {
             foreach ( $totable->indexes as $name=>$toindex ) {
                 $match = false;
                 foreach ($fromtable->indexes as $name=>$fromindex ) {
-                    $match = $toindex->equal_to( $fromindex );
+                    $match = $toindex->equal_to( $fromindex, $fromnames );
                     if ( $match ) { break; }
                 }
                 if ( ! $match ) {
@@ -259,7 +259,7 @@ class Modyllic_Diff {
             foreach ( $fromtable->indexes as $name=>$fromindex ) {
                 $match = false;
                 foreach ($totable->indexes as $name=>$toindex ) {
-                    $match = $fromindex->equal_to( $toindex );
+                    $match = $fromindex->equal_to( $toindex, $tonames );
                     if ( $match ) { break; }
                 }
                 if ( ! $match ) {

--- a/Modyllic/Generator/MySQL.php
+++ b/Modyllic/Generator/MySQL.php
@@ -583,7 +583,7 @@ class Modyllic_Generator_MySQL {
         if ( $column->from ) {
             $this->reindent("--  ");
             $this->partial( "BEFORE        ");
-            $this->create_column( $column->from );
+            $this->create_column( $column->from, false );
             $this->reindent();
         }
         if ( $column->previously != $column->name ) {
@@ -592,7 +592,7 @@ class Modyllic_Generator_MySQL {
         else {
             $this->partial( "MODIFY COLUMN " );
         }
-        $this->create_column($column);
+        $this->create_column($column, false);
         return $this;
     }
 
@@ -601,7 +601,7 @@ class Modyllic_Generator_MySQL {
         return $this;
     }
 
-    function create_column( $column ) {
+    function create_column( $column, $with_key=true ) {
         if ( isset($column->from) ) {
             $this->extend("%id %lit", $column->name, $column->type->to_sql($column->from->type) );
         }
@@ -622,7 +622,7 @@ class Modyllic_Generator_MySQL {
         if ( $column->on_update ) {
             $this->add( " ON UPDATE %lit", $column->on_update );
         }
-        if ( $column->is_primary ) {
+        if ( $with_key and $column->is_primary ) {
             $this->add( " PRIMARY KEY" );
         }
         return $this;
@@ -1095,8 +1095,9 @@ class Modyllic_Generator_MySQL {
     function update_meta($kind,$which,array $meta) {
         if ( ! isset($this->what['sqlmeta']) ) { return; }
         if ( count($meta) > 0 ) {
-            $this->cmd( "INSERT INTO SQLMETA SET kind=%str, which=%str, value=%str ON DUPLICATE KEY UPDATE meta=%str",
-                 $kind, $which, $meta, $meta );
+            $meta_str = json_encode($meta);
+            $this->cmd( "INSERT INTO SQLMETA SET kind=%str, which=%str, value=%str ON DUPLICATE KEY UPDATE value=%str",
+                 $kind, $which, $meta_str, $meta_str );
         }
         else {
             if ( ! $this->to_sqlmeta_exists ) { return; }

--- a/Modyllic/Schema/Index.php
+++ b/Modyllic/Schema/Index.php
@@ -35,9 +35,20 @@ class Modyllic_Schema_Index extends Modyllic_Diffable {
      * @param Modyllic_Index $other
      * @returns bool True if $other is equivalent to $this
      */
-    function equal_to($other) {
+    function equal_to($other, $fromnames=null) {
         if ( get_class($other) != get_class($this) )   { return false; }
-        if ( $this->columns != $other->columns ) { return false; }
+        if ( isset($fromnames) ) {
+            if ( count($this->columns) != count($other->columns) ) { return false; }
+            foreach ($other->columns as $name=>$column) {
+                if ( ! isset($this->columns[$fromnames[$name]]) and
+                     ! isset($this->columns[$name]) ) {
+                    return false;
+                }
+            }
+        }
+        else {
+            if ( $this->columns != $other->columns ) { return false; }
+        }
         if ( $this->primary != $other->primary ) { return false; }
         if ( $this->fulltext != $other->fulltext ) { return false; }
         if ( $this->unique != $other->unique ) { return false; }

--- a/Modyllic/Schema/Index/Foreign.php
+++ b/Modyllic/Schema/Index/Foreign.php
@@ -26,7 +26,7 @@ class Modyllic_Schema_Index_Foreign extends Modyllic_Schema_Index {
         return "~".$this->cname;
     }
 
-    function equal_to($other) {
+    function equal_to($other, $fromnames=null) {
         if ( ! parent::equal_to($other) )               { return false; }
         if ( $this->references != $other->references ) { return false; }
         if ( $this->weak != $other->weak )             { return false; }


### PR DESCRIPTION
We also suppress the inclusion of "PRIMARY KEY" statements when changing a column, as these are not actually a part of the column specifier.
