### PR TITLE
Revert 85a11a8 from #85-- PHP globs don't work that way

### DIFF
--- a/Modyllic/Loader/Dir.php
+++ b/Modyllic/Loader/Dir.php
@@ -13,7 +13,7 @@ class Modyllic_Loader_Dir {
     static function load( $dir, $schema ) {
         $filelist = array_merge(
             glob("$dir/*.sql",GLOB_NOSORT),
-            glob("$dir/*/",GLOB_NOSORT) );
+            glob("$dir/*",GLOB_NOSORT|GLOB_ONLYDIR) );
         natsort($filelist);
         Modyllic_Loader::load( $filelist, $schema );
     }


### PR DESCRIPTION
In php glob('foo/*/') matches all files in the foo directory, not only
directories like it does in every other language.

ARGHBLBLBL
