### PR TITLE
Fix bug where data updates would get lost if a tables static status did not change

### DIFF
--- a/Modyllic/Changeset/Table.php
+++ b/Modyllic/Changeset/Table.php
@@ -111,20 +111,24 @@ class Modyllic_Changeset_Table {
         $this->update['data'][] = array("updated"=>$updated,"where"=>$where,"from"=>$from);
     }
 
+    function has_data_changes() {
+         return count($this->add['data']) + count($this->remove['data']) + count($this->update['data']);
+    }
+
     /**
      * Check to see if this object actually contains any changes
      */
     function has_changes() {
-         $changed_data = count($this->add['data']) + count($this->remove['data']) + count($this->update['data']);
-         return $this->has_schema_changes() or $changed_data!=0;
+         return $this->has_schema_changes() or $this->has_data_changes();
     }
 
     function has_schema_changes() {
         $changed
             = count($this->add['columns']) + count($this->remove['columns']) + count($this->update['columns'])
-            + count($this->add['indexes']) + count($this->remove['indexes']) + ($this->static != $this->from->static )
+            + count($this->add['indexes']) + count($this->remove['indexes']) + isset($this->static)
             + $this->options->has_changes()
             ;
          return $changed;
     }
+
 }

--- a/Modyllic/Generator/MySQL.php
+++ b/Modyllic/Generator/MySQL.php
@@ -504,39 +504,37 @@ class Modyllic_Generator_MySQL {
         if ( isset($table->static) and $table->static and ! $table->from->static ) {
             $this->cmd("TRUNCATE %id", $table->name);
         }
-        if ( $table->static ) {
-            foreach ($table->remove['data'] as $row ) {
-                $this->begin_cmd();
-                $this->partial( "DELETE FROM %id WHERE ", $table->name);
-                $this->begin_list( " AND " );
-                foreach ($row as $col=>$val) {
-                    $this->next_list_item();
-                    $this->partial( "%id=%lit", $col, $val );
-                }
-                $this->end_list();
-                $this->end_cmd();
+        foreach ($table->remove['data'] as $row ) {
+            $this->begin_cmd();
+            $this->partial( "DELETE FROM %id WHERE ", $table->name);
+            $this->begin_list( " AND " );
+            foreach ($row as $col=>$val) {
+                $this->next_list_item();
+                $this->partial( "%id=%lit", $col, $val );
             }
-            foreach ($table->update['data'] as $row ) {
-                $this->begin_cmd();
-                $this->partial( "UPDATE %id SET ", $table->name );
-                $this->begin_list();
-                foreach ($row['updated'] as $col=>$val) {
-                    $this->next_list_item();
-                    $this->partial( "%id=%lit", $col, $val );
-                }
-                $this->end_list();
-                $this->partial(" WHERE ");
-                $this->begin_list(" AND ");
-                foreach ($row['where'] as $col=>$val) {
-                    $this->next_list_item();
-                    $this->partial( "%id=%lit", $col, $val );
-                }
-                $this->end_list();
-                $this->end_cmd();
+            $this->end_list();
+            $this->end_cmd();
+        }
+        foreach ($table->update['data'] as $row ) {
+            $this->begin_cmd();
+            $this->partial( "UPDATE %id SET ", $table->name );
+            $this->begin_list();
+            foreach ($row['updated'] as $col=>$val) {
+                $this->next_list_item();
+                $this->partial( "%id=%lit", $col, $val );
             }
-            foreach ($table->add['data'] as $row ) {
-                $this->create_data( $table, $row );
+            $this->end_list();
+            $this->partial(" WHERE ");
+            $this->begin_list(" AND ");
+            foreach ($row['where'] as $col=>$val) {
+                $this->next_list_item();
+                $this->partial( "%id=%lit", $col, $val );
             }
+            $this->end_list();
+            $this->end_cmd();
+        }
+        foreach ($table->add['data'] as $row ) {
+            $this->create_data( $table, $row );
         }
         return $this;
     }


### PR DESCRIPTION
This was resulting in weird situations, like migrate thinking it had changes to apply, but then not actually doing anything to the database.
