### PR TITLE
Fix formatting of proc_return_type and routine_args_type docs

### DIFF
--- a/doc/Dialect.md
+++ b/doc/Dialect.md
@@ -243,6 +243,7 @@ proc_return_type:
     | NONE
 
 routine_args_type:
+
       LIST
     | MAP
 


### PR DESCRIPTION
These weren't correctly markdown formatted.
