### PR TITLE
Fix #191 -- Emit BIGINTs for SERIAL columns

### DIFF
--- a/Modyllic/Generator/ModyllicSQL.php
+++ b/Modyllic/Generator/ModyllicSQL.php
@@ -613,35 +613,90 @@ class Modyllic_Generator_ModyllicSQL {
         return $this;
     }
 
-    function create_column( Modyllic_Schema_Column $column, $with_key=true ) {
-        if ( isset($column->from) ) {
-            $this->extend("%id %lit", $column->name, $column->type->to_sql($column->from->type) );
+    function emit_type( $type, $from_type = null ) {
+        $this->add( $type->to_sql( $from_type ) );
+        return $this;
+    }
+
+    function column_not_null( Modyllic_Schema_Column $column ) {
+        return ! $column->type instanceOf Modyllic_Type_Serial and ! $column->null;
+    }
+
+    function emit_column_null( Modyllic_Schema_Column $column ) {
+        if ( $this->column_not_null($column) ) {
+            $this->add( " NOT NULL" );
         }
-        else {
-            $this->extend("%id %lit", $column->name, $column->type->to_sql() );
+        return $this;
+    }
+
+    function column_auto_increment( Modyllic_Schema_Column $column ) {
+        return ! $column->type instanceOf Modyllic_Type_Serial and $column->auto_increment;
+    }
+
+    function emit_column_auto_increment( Modyllic_Schema_Column $column ) {
+        if ( $this->column_auto_increment($column) ) {
+            $this->add( " auto_increment" );
         }
-        if ( ! $column->type instanceOf Modyllic_Type_Serial ) {
-            if ( ! $column->null ) {
-                $this->add( " NOT NULL" );
-            }
-            if ( $column->auto_increment ) {
-                $this->add( " auto_increment" );
-            }
+        return $this;
+    }
+
+    function column_show_default( Modyllic_Schema_Column $column ) {
+        return ! is_null($column->default) and (!$column->null or $column->default!='NULL');
+    }
+    function emit_column_default( Modyllic_Schema_Column $column ) {
+        if ( $this->column_show_default($column) ) {
+            $this->add( " DEFAULT %lit", $column->default );
         }
-        if ( ! is_null($column->default) ) {
-            if ( !$column->null or $column->default!='NULL' ) {
-                $this->add( " DEFAULT %lit", $column->default );
-            }
-        }
-        if ( $column->on_update ) {
+        return $this;
+    }
+
+    function column_on_update( Modyllic_Schema_Column $column ) {
+        return $column->on_update;
+    }
+    function emit_column_on_update( Modyllic_Schema_Column $column ) {
+        if ( $this->column_on_update($column) ) {
             $this->add( " ON UPDATE %lit", $column->on_update );
         }
-        if ( $with_key and $column->is_primary ) {
+        return $this;
+    }
+
+    function column_is_primary( Modyllic_Schema_Column $column ) {
+        return $column->is_primary;
+    }
+    function emit_column_is_primary( Modyllic_Schema_Column $column ) {
+        if ( $this->column_is_primary($column) ) {
             $this->add( " PRIMARY KEY" );
         }
-        if ( $with_key and $column->unique and ! $column->type instanceOf Modyllic_Type_Serial ) {
+        return $this;
+    }
+
+    function column_unique( Modyllic_Schema_Column $column ) {
+        return $column->unique and ! $column->is_primary;
+    }
+    function emit_column_unique( Modyllic_Schema_Column $column ) {
+        if ( $this->column_unique($column) ) {
             $this->add( " UNIQUE" );
         }
+        return $this;
+    }
+
+    function create_column( Modyllic_Schema_Column $column, $with_key=true ) {
+        $this->extend("%id ", $column->name );
+        if ( isset($column->from) ) {
+            $this->emit_type( $column->type, $column->from->type );
+        }
+        else {
+            $this->emit_type( $column->type );
+        }
+        $this->emit_column_null( $column );
+        $this->emit_column_auto_increment( $column );
+        $this->emit_column_default( $column );
+        $this->emit_column_on_update( $column );
+        if ( $with_key ) {
+            $this->emit_column_is_primary( $column );
+            $this->emit_column_unique( $column );
+        }
+
         $this->column_aliases($column);
         return $this;
     }

--- a/Modyllic/Generator/MySQL.php
+++ b/Modyllic/Generator/MySQL.php
@@ -23,6 +23,25 @@ class Modyllic_Generator_MySQL extends Modyllic_Generator_ModyllicSQL {
 
     function column_aliases( Modyllic_Schema_Column $column ) {}
 
+    function emit_type( $type, $from_type = null ) {
+        if ( $type instanceOf Modyllic_Type_Serial ) {
+            $bigint = Modyllic_Type::create("BIGINT");
+            $bigint->unsigned = true;
+            $this->add( $bigint->to_sql() );
+        }
+        else {
+            parent::emit_type( $type, $from_type );
+        }
+    }
+
+    function column_auto_increment( Modyllic_Schema_Column $column ) {
+        return $column->auto_increment;
+    }
+
+    function column_not_null( Modyllic_Schema_Column $column ) {
+        return ! $column->null;
+    }
+
     function foreign_key_weakly_references(Modyllic_Schema_Index $index) {
         $this->foreign_key_regular_references($index);
     }


### PR DESCRIPTION
We expand the SERIAL alias with MySQL now.  This allows us to elide the
UNIQUE flag on SERIAL columns that are also PRIMARY KEYs.
