### PR TITLE
Set indexes associated with primary key columns as column defined, which...

### DIFF
--- a/Modyllic/Generator/ModyllicSQL.php
+++ b/Modyllic/Generator/ModyllicSQL.php
@@ -423,10 +423,6 @@ class Modyllic_Generator_ModyllicSQL {
         $completed = 0;
         foreach ( $table->columns as $column ) {
             $this->create_column( $column );
-            if ( $column->is_primary ) {
-                unset($indexes['!PRIMARY KEY']);
-                $entries --;
-            }
             if ( ++$completed < $entries ) {
                 $this->add(",");
             }

--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -1020,6 +1020,7 @@ class Modyllic_Parser {
             $index = new Modyllic_Schema_Index('!PRIMARY KEY');
             $index->primary = true;
             $index->columns = array($column->name => false);
+            $index->column_defined = true;
             $this->add_index( $index );
         }
         else if ( $column->unique ) {


### PR DESCRIPTION
... saves

us from having to have a special case is_primary check later on.
