### PR TITLE
Fix 'HASH' type reserved word

### DIFF
--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -1364,7 +1364,7 @@ class Modyllic_Parser {
      * @returns the token form of the reserved word (all caps)
      */
     function assert_reserved( $t1=null ) {
-        if ( ! $this->cur() instanceOf Modyllic_Token_Reserved ) {
+        if ( ! $this->cur() instanceOf Modyllic_Token_Bareword ) {
             throw $this->error( "Expected reserved word, got ".$this->cur()->debug() );
         }
         if ( is_null($t1) ) { return $this->cur()->token(); }

--- a/Modyllic/Token/Bareword.php
+++ b/Modyllic/Token/Bareword.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Copyright Â© 2012 Online Buddies, Inc. - All Rights Reserved
+ *
+ * @package Modyllic
+ * @author bturner@online-buddies.com
+ */
+
+/**
+ * Bareword type tokens
+ */
+interface Modyllic_Token_Bareword { }

--- a/Modyllic/Token/Ident.php
+++ b/Modyllic/Token/Ident.php
@@ -9,7 +9,7 @@
 /**
  * Identifiers, eg, column names, table names, etc.
  */
-class Modyllic_Token_Ident extends Modyllic_Token {
+class Modyllic_Token_Ident extends Modyllic_Token implements Modyllic_Token_Bareword {
     private $upper;
     function token() {
         if ( isset($this->upper) ) {

--- a/Modyllic/Token/Reserved.php
+++ b/Modyllic/Token/Reserved.php
@@ -9,4 +9,14 @@
 /**
  * Reserved words
  */
-class Modyllic_Token_Reserved extends Modyllic_Token_Ident { }
+class Modyllic_Token_Reserved extends Modyllic_Token implements Modyllic_Token_Bareword {
+    private $upper;
+    function token() {
+        if ( isset($this->upper) ) {
+            return $this->upper;
+        }
+        else {
+            return $this->upper = strtoupper($this->value());
+        }
+    }
+}

--- a/Modyllic/Tokenizer.php
+++ b/Modyllic/Tokenizer.php
@@ -552,7 +552,6 @@ class Modyllic_Tokenizer {
             "FOREIGN KEY",
             "GEOMETRY",
             "GEOMETRYCOLLECTION",
-            "HASH",
             "HEAP",
             "HOUR",
             "HOUR_MINUTE",

--- a/test/parser/Errors.t
+++ b/test/parser/Errors.t
@@ -36,7 +36,7 @@ try {
     fail($msg);
 }
 catch (Modyllic_Exception $e) {
-    like($e->getMessage(),"/Expected reserved word, got/", $msg);
+    like($e->getMessage(),"/Unsupported SQL command/", $msg);
 }
 
 $error3_sql = <<< EOSQL


### PR DESCRIPTION
Fixes #206, we remove HASH from the keyword list, add a new type called "Bareword" that can be an Ident OR a Reserved word.  The parser will now accept Barewords for reserved words.  Long term, we will want to remove all reserved words that are not required for unambiguous parsing.
