### PR TITLE
Fix #192: Adding multiple columns resulted in invalid AFTER clauses

### DIFF
--- a/Modyllic/Diff.php
+++ b/Modyllic/Diff.php
@@ -228,9 +228,9 @@ class Modyllic_Diff {
                     continue;
                 }
                 $fromcolumn = $fromtable->columns[$fromname];
+                $tocolumn->from = $fromcolumn;
                 if ( ! $tocolumn->equal_to($fromcolumn) ) {
                     $tocolumn->previously = $fromname;
-                    $tocolumn->from = $fromcolumn;
                     $tablediff->update_column($tocolumn);
                 }
 

--- a/Modyllic/Generator/ModyllicSQL.php
+++ b/Modyllic/Generator/ModyllicSQL.php
@@ -408,7 +408,7 @@ class Modyllic_Generator_ModyllicSQL {
                 if ($table->options->has_changes()) {
                     $this->table_options( $table->options );
                 }
-                foreach ($table->add['columns'] as $column) {
+                foreach (array_reverse($table->add['columns']) as $column) {
                     $this->add_column( $column );
                 }
                 foreach ($table->remove['columns'] as $column) {
@@ -492,7 +492,13 @@ class Modyllic_Generator_ModyllicSQL {
             $this->add( " FIRST" );
         }
         else {
-            $this->add( " AFTER %id", $column->after );
+            $after = $column->after;
+            while ( ! isset($after->from) and isset($after->after) ) {
+                $after = $after->after;
+            }
+            if ( isset($after->from) ) {
+                $this->add( " AFTER %id", $after->name );
+            }
         }
         $this->column_aliases($column);
         return $this;

--- a/Modyllic/Schema/Table.php
+++ b/Modyllic/Schema/Table.php
@@ -50,7 +50,7 @@ class Modyllic_Schema_Table extends Modyllic_Diffable {
      */
     function add_column(Modyllic_Schema_Column $column) {
         if ( isset($this->last_column) ) {
-            $column->after = $this->last_column->name;
+            $column->after = $this->last_column;
         }
         $this->last_column = $column;
         $this->columns[$column->name] = $column;


### PR DESCRIPTION
We fix this by traversing our way back up the column list using the after field to find the first column that has a "from" attribute.  The from attribute will be set if it exists in both schema.

Because multiple columns will be added AFTER the same column, we have to reverse the order to make MySQL Do The Right Thing.
