### PR TITLE
Fixes #240 SPATIAL KEY support, fixing reversion from reserved refactor (2575f3c)

### DIFF
--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -822,7 +822,7 @@ class Modyllic_Parser {
             }
 
             # A key or column spec, followed by...
-            if ( $this->is_reserved(array( "CONSTRAINT", "FOREIGN KEY", "PRIMARY KEY", "UNIQUE", "FULLTEXT", "KEY"  )) ) {
+            if ( $this->is_reserved(array( "CONSTRAINT", "FOREIGN KEY", "PRIMARY KEY", "UNIQUE", "FULLTEXT", "SPATIAL", "KEY"  )) ) {
                 $last_was = $this->load_key();
             }
             else {


### PR DESCRIPTION
The reserved words refactor resulted in a reversion.  The parser generally needs cleanup to bring it more tightly in-line with the spec while making it cleaner.
