### PR TITLE
Support default lengths varying based on signedness

### DIFF
--- a/Modyllic/Generator/PHP.php
+++ b/Modyllic/Generator/PHP.php
@@ -870,8 +870,8 @@ class Modyllic_Generator_PHP {
         return $this;
     }
     function arg_validate_string(Modyllic_Schema_Arg $arg) {
-        if ( isset($arg->type->length) ) {
-            $this->validate_string_length($arg->name, $arg->type->length);
+        if ( !is_null($arg->type->length()) ) {
+            $this->validate_string_length($arg->name, $arg->type->length());
         }
         return $this;
     }

--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -745,11 +745,11 @@ class Modyllic_Parser {
             }
             else {
                 $type->length = $this->get_list();
-                if ( $type instanceOf Modyllic_Type_VarChar and $type->length > 65535 ) {
-                    $type = new Modyllic_Type_Text($type->name,$type->length);
+                if ( $type instanceOf Modyllic_Type_VarChar and $type->length() > 65535 ) {
+                    $type = new Modyllic_Type_Text($type->name,$type->length());
                 }
-                else if ( $type instanceOf Modyllic_Type_VarBinary and $type->length > 65535 ) {
-                    $type = new Modyllic_Type_Blob($type->name,$type->length);
+                else if ( $type instanceOf Modyllic_Type_VarBinary and $type->length() > 65535 ) {
+                    $type = new Modyllic_Type_Blob($type->name,$type->length());
                 }
             }
         }

--- a/Modyllic/Type.php
+++ b/Modyllic/Type.php
@@ -126,4 +126,19 @@ abstract class Modyllic_Type {
     function is_valid() {
         return true;
     }
+
+    public $length = null;
+
+    public $default_length = null;
+
+    function length() {
+        if ( isset($this->length) ) {
+            return $this->length;
+        }
+        return $this->length = $this->default_length();
+    }
+
+    function default_length() {
+        return $this->default_length;
+    }
 }

--- a/Modyllic/Type/Char.php
+++ b/Modyllic/Type/Char.php
@@ -10,12 +10,11 @@ class Modyllic_Type_Char extends Modyllic_Type_VarString {
     public $default_length = 1;
     function __construct($type) {
         parent::__construct($type);
-        $this->length = $this->default_length;
     }
     function to_sql(Modyllic_Type $other=null) {
         $sql = $this->name;
-        if ( $this->length != $this->default_length ) {
-            $sql .= "(".$this->length.")";
+        if ( $this->length() != $this->default_length() ) {
+            $sql .= "(".$this->length().")";
         }
         $sql .= $this->charset_collation($other);
         return $sql;

--- a/Modyllic/Type/Decimal.php
+++ b/Modyllic/Type/Decimal.php
@@ -17,8 +17,8 @@ class Modyllic_Type_Decimal extends Modyllic_Type_Numeric {
 
     function to_sql() {
         $sql = $this->name;
-        if ( $this->length != $this->default_length  or $this->scale != $this->default_scale ) {
-            $sql .= '(' . $this->length . ',' . $this->scale . ')';
+        if ( $this->length() != $this->default_length()  or $this->scale != $this->default_scale ) {
+            $sql .= '(' . $this->length() . ',' . $this->scale . ')';
         }
         if ( $this->unsigned ) {
             $sql .= ' UNSIGNED';

--- a/Modyllic/Type/Float.php
+++ b/Modyllic/Type/Float.php
@@ -11,7 +11,7 @@ class Modyllic_Type_Float extends Modyllic_Type_Numeric {
     function to_sql() {
         $sql = $this->name;
         if ( $this->decimals ) {
-            $sql .= '(' . $this->length . ',' . $this->decimals . ')';
+            $sql .= '(' . $this->length() . ',' . $this->decimals . ')';
         }
         if ( $this->unsigned ) {
             $sql .= ' UNSIGNED';
@@ -27,7 +27,7 @@ class Modyllic_Type_Float extends Modyllic_Type_Numeric {
         if ( $this->zerofill != $other->zerofill ) { return false; }
         if ( $this->decimals != $other->decimals ) { return false; }
         if ( $this->decimals ) {
-            if ( $this->length != $other->length) { return false; }
+            if ( $this->length() != $other->length()) { return false; }
         }
         return true;
     }

--- a/Modyllic/Type/Integer.php
+++ b/Modyllic/Type/Integer.php
@@ -19,8 +19,8 @@ class Modyllic_Type_Integer extends Modyllic_Type_Numeric {
     }
     function to_sql() {
         $sql = $this->name;
-        if ( $this->length != $this->default_length ) {
-            $sql .= '(' . $this->length . ')';
+        if ( $this->length() != $this->default_length() ) {
+            $sql .= '(' . $this->length() . ')';
         }
         if ( $this->unsigned ) {
             $sql .= ' UNSIGNED';

--- a/Modyllic/Type/Numeric.php
+++ b/Modyllic/Type/Numeric.php
@@ -8,26 +8,29 @@
 
 abstract class Modyllic_Type_Numeric extends Modyllic_Type {
     public $default_length = 11;
-    public $length;
     public $unsigned = false;
     public $zerofill = false;
 
     function __construct($type) {
         parent::__construct($type);
-        $this->length = $this->default_length;
     }
+
+    function default_length() {
+        return $this->default_length + ($this->unsigned ? -1 : 0 );
+    }
+
     function equal_to(Modyllic_Type $other) {
         if ( ! parent::equal_to($other) ) { return false; }
         if ( $this->unsigned != $other->unsigned ) { return false; }
         if ( $this->zerofill != $other->zerofill ) { return false; }
-        if ( $this->length != $other->length) { return false; }
+        if ( $this->length() != $other->length()) { return false; }
         return true;
     }
     function copy_from(Modyllic_Type $old) {
         parent::copy_from($old);
         $this->unsigned = $old->unsigned;
         $this->zerofill = $old->zerofill;
-        $this->length = $old->length;
+        $this->length = $old->length();
     }
     function numify($value) {
         if ( $value instanceOf Modyllic_Token_String ) {

--- a/Modyllic/Type/String.php
+++ b/Modyllic/Type/String.php
@@ -11,7 +11,6 @@ abstract class Modyllic_Type_String extends Modyllic_Type {
     protected $default_collate = "utf8_general_ci";
     private $charset;
     private $collate;
-    public $length;
 
     function set_default_charset($value) {
         $this->default_charset = $value;
@@ -69,8 +68,8 @@ abstract class Modyllic_Type_String extends Modyllic_Type {
         else {
             throw new Exception( "Expected a valid string, got: $str" );
         }
-        if ( isset($this->length) ) {
-            $value = substr( $value, 0, $this->length );
+        if ( !is_null($this->length()) ) {
+            $value = substr( $value, 0, $this->length() );
         }
         return Modyllic_SQL::quote_str( $value );
     }

--- a/Modyllic/Type/Text.php
+++ b/Modyllic/Type/Text.php
@@ -13,17 +13,17 @@ class Modyllic_Type_Text extends Modyllic_Type_String {
     }
     function copy_from(Modyllic_Type $old) {
         parent::copy_from($old);
-        $this->length = $old->length;
+        $this->length = $old->length();
     }
     function type_name($size) { return $size . "TEXT"; }
     function to_sql(Modyllic_Type $other=null) {
-        if ( $this->length < 256 ) { // 2^8
+        if ( $this->length() < 256 ) { // 2^8
             $sql = $this->type_name("TINY");
         }
-        else if ( $this->length < 65536 ) { // 2^16
+        else if ( $this->length() < 65536 ) { // 2^16
             $sql = $this->type_name("");
         }
-        else if ( $this->length < 16777216 ) { // 2^24
+        else if ( $this->length() < 16777216 ) { // 2^24
             $sql = $this->type_name("MEDIUM");
         }
         else {

--- a/Modyllic/Type/VarString.php
+++ b/Modyllic/Type/VarString.php
@@ -9,19 +9,19 @@
 abstract class Modyllic_Type_VarString extends Modyllic_Type_String {
     function equal_to(Modyllic_Type $other) {
         if ( ! parent::equal_to($other) ) { return false; }
-        if ( $this->length != $other->length ) { return false; }
+        if ( $this->length() != $other->length() ) { return false; }
         return true;
     }
     function copy_from(Modyllic_Type $old) {
         parent::copy_from($old);
-        $this->length = $old->length;
+        $this->length = $old->length();
     }
     function to_sql(Modyllic_Type $other=null) {
-        $sql = $this->name . "(".$this->length.")";
+        $sql = $this->name . "(".$this->length().")";
         $sql .= $this->charset_collation($other);
         return $sql;
     }
     function is_valid() {
-        return isset($this->length) and parent::is_valid();
+        return !is_null($this->length()) and parent::is_valid();
     }
 }

--- a/Modyllic/Type/Year.php
+++ b/Modyllic/Type/Year.php
@@ -8,27 +8,26 @@
 
 class Modyllic_Type_Year extends Modyllic_Type {
     public $default_length = 4;
-    public $length;
+
     function __construct($type) {
         parent::__construct($type);
-        $this->length = $this->default_length;
     }
 
     function to_sql() {
         $sql = $this->name;
-        if ( $this->length != $this->default_length ) {
-            $sql .= '(' . $this->length . ')';
+        if ( $this->length() != $this->default_length() ) {
+            $sql .= '(' . $this->length() . ')';
         }
         return $sql;
     }
     function equal_to(Modyllic_Type $other) {
         if ( ! parent::equal_to($other) ) { return false; }
-        if ( $this->length != $other->length ) { return false; }
+        if ( $this->length() != $other->length() ) { return false; }
         return true;
     }
     function copy_from(Modyllic_Type $old) {
         parent::copy_from($old);
-        $this->length = $old->length;
+        $this->length = $old->length();
     }
     function normalize($year) {
         $is_object = is_object($year);

--- a/test/Types.t
+++ b/test/Types.t
@@ -68,7 +68,7 @@ catch (Exception $e) {
 }
 
 $bool = Modyllic_Type::create("BOOLEAN");
-is( $bool->length, 1, "Boolean always have a length of 1");
+is( $bool->length(), 1, "Boolean always have a length of 1");
 is( $bool->to_sql(), "BOOLEAN", "Boolean types properly become themselves");
 $tinyint = Modyllic_Type::create("TINYINT");
 ok( $bool->isa_equivalent($tinyint), "BOOLEAN as a type is equivalent of TINYINT");
@@ -88,4 +88,4 @@ ok( $bit->equal_to($bit), "Bits are indeed bits" );
 ok( $bit->is_valid(), "Bits are valid" );
 
 $int = Modyllic_Type::create("INTEGER");
-is( $int->length, $int->default_length, "Length is initialized properly" );
+is( $int->length(), $int->default_length(), "Length is initialized properly" );


### PR DESCRIPTION
Do this by making the length of types lazily computed, and the
default_length purely computed.

A side effect of this is that we push length and default_length up to the
top-level Type interface, and it's just null for types that don't have
lengths.
