### PR TITLE
Fix #249: Guard against events not existing in MySQL 5.0

### DIFF
--- a/Modyllic/Loader/DB/MySQL.php
+++ b/Modyllic/Loader/DB/MySQL.php
@@ -68,12 +68,17 @@ class Modyllic_Loader_DB_MySQL {
             $views[$view_row['TABLE_NAME']] = $view['Create View'];
         }
 
-        $event_sth = self::query( $dbh, "SELECT EVENT_NAME FROM EVENTS WHERE EVENT_SCHEMA=?", array($dbname) );
-        $events = array();
-        while ( $event_row = $event_sth->fetch(PDO::FETCH_ASSOC) ) {
-            Modyllic_Status::$source_count ++;
-            $event = self::selectrow( $dbh, "SHOW CREATE EVENT ".Modyllic_SQL::quote_ident($dbname).".".Modyllic_SQL::quote_ident($event_row['EVENT_NAME']) );
-            $events[$event_row['EVENT_NAME']] = $event['Create Event'];
+        // Events don't exist in MySQL 5.0
+        $events_exist_sth = self::query( $dbh, "SELECT 1 FROM TABLES WHERE TABLE_SCHEMA='information_schema' AND TABLE_NAME='EVENTS'", array() );
+        $events_exist = $event_sth->fetch(PDO::FETCH_NUM);
+        if ($events_exist) {
+            $event_sth = self::query( $dbh, "SELECT EVENT_NAME FROM EVENTS WHERE EVENT_SCHEMA=?", array($dbname) );
+            $events = array();
+            while ( $event_row = $event_sth->fetch(PDO::FETCH_ASSOC) ) {
+                Modyllic_Status::$source_count ++;
+                $event = self::selectrow( $dbh, "SHOW CREATE EVENT ".Modyllic_SQL::quote_ident($dbname).".".Modyllic_SQL::quote_ident($event_row['EVENT_NAME']) );
+                $events[$event_row['EVENT_NAME']] = $event['Create Event'];
+            }
         }
 
         $trigger_sth = self::query( $dbh, "SELECT TRIGGER_NAME FROM TRIGGERS WHERE TRIGGER_SCHEMA=?", array($dbname) );


### PR DESCRIPTION
The only major schema component that's been added since MySQL 5.0 is events– in order to support MySQL 5.0 we need to guard against trying to load them in that version.

Note: This does not provide a MySQL 5.0 emitter mode that puts MySQL 5.0 events into the MODYLLIC table or some such, at this time.  The fact that trying to load a schema with events into MySQL 5.0 produces an error is something I consider a feature. (Long term, it will need to support this sort of thing, as cross-loading MySQL/PostgreSQL will encounter this all the time.)
