### PR TITLE
Remove needless body rewriting

### DIFF
--- a/Modyllic/Parser.php
+++ b/Modyllic/Parser.php
@@ -666,12 +666,7 @@ class Modyllic_Parser {
                     throw $this->error("Unknown characteristic in routine declaration: ".$this->cur()->debug());
             }
         }
-        if ( $this->peek_next()->token() == 'BEGIN' ) {
-            $routine->body = trim($this->rest());
-        }
-        else {
-            $routine->body = "BEGIN\n    " . trim($this->rest()) . "\nEND";
-        }
+        $routine->body = trim($this->rest());
     }
 
     private $column_term = array( ',', ')' );


### PR DESCRIPTION
In earlier, more naive versions of the parser, ensuring that the bodies of
procs, events and triggers were always in BEGIN / END blocks was helpful,
but this has been unnecessary for a long time, and only adds needless room
for new errors to creep in.
